### PR TITLE
V1.5 - Resolve tickets related to Post-UC Release 2015 - Milestone

### DIFF
--- a/js/library/nls/en/localizedStrings.js
+++ b/js/library/nls/en/localizedStrings.js
@@ -94,7 +94,7 @@ define({
         commentString: "Please enter comment", // Shown when Submit button in Comments pod of infoWindow pod is clicled/tapped without entering the comment.
         maxLengthCommentString: "Comment should not exceed 250 characters .", // // Shown when Submit button in Comments pod of infoWindow pod is clicled/tapped and the comment string exceeds 250 words.
         commentError: "Unable to add comments. Comments table is either absent or does not have write access.", // Shown when Submit button in Comments pod of infoWindow pod is clicled/tapped and the application isunable to add comments.
-        addedActivities: "All activities within specified date range are already added to the My List.", // Shown when all the activities are added in My list from Event planner.
+        addedActivities: "All activities within specified date range are already added to My List.", // Shown when all the activities are added in My list from Event planner.
         activitySearchGeolocationText: "Geolocation is not supported in selected browser.", // Shown when searching activity/event using IE8 browser.
         portalUrlNotFound: "Portal URL cannot be empty", // Setting error message when portal url is empty.
         activityAlreadyAdded: "This feature is already added to list", // Shown when a particular feature already exist in My list and is again attempted to be added to My List.

--- a/js/library/nls/es/localizedStrings.js
+++ b/js/library/nls/es/localizedStrings.js
@@ -94,7 +94,7 @@ define({
         commentString: "@es@ Please enter comment", // Shown when Submit button in Comments pod of infoWindow pod is clicled/tapped without entering the comment.
         maxLengthCommentString: "@es@ Comment should not exceed 250 characters .", // // Shown when Submit button in Comments pod of infoWindow pod is clicled/tapped and the comment string exceeds 250 words.
         commentError: "@es@ Unable to add comments. Comments table is either absent or does not have write access.", // Shown when Submit button in Comments pod of infoWindow pod is clicled/tapped and the application isunable to add comments.
-        addedActivities: "@es@ All activities within specified date range are already added to the My List.", // Shown when all the activities are added in My list from Event planner.
+        addedActivities: "@es@ All activities within specified date range are already added to My List.", // Shown when all the activities are added in My list from Event planner.
         activitySearchGeolocationText: "@es@ Geolocation is not supported in selected browser.", // Shown when searching activity/event using IE8 browser.
         portalUrlNotFound: "@es@ Portal URL cannot be empty", // Setting error message when portal url is empty.
         activityAlreadyAdded: "@es@ This feature is already added to list", // Shown when a particular feature already exist in My list and is again attempted to be added to My List.

--- a/js/library/nls/fr/localizedStrings.js
+++ b/js/library/nls/fr/localizedStrings.js
@@ -94,7 +94,7 @@ define({
         commentString: "@fr@ Please enter comment", // Shown when Submit button in Comments pod of infoWindow pod is clicled/tapped without entering the comment.
         maxLengthCommentString: "@fr@ Comment should not exceed 250 characters .", // // Shown when Submit button in Comments pod of infoWindow pod is clicled/tapped and the comment string exceeds 250 words.
         commentError: "@fr@ Unable to add comments. Comments table is either absent or does not have write access.", // Shown when Submit button in Comments pod of infoWindow pod is clicled/tapped and the application isunable to add comments.
-        addedActivities: "@fr@ All activities within specified date range are already added to the My List.", // Shown when all the activities are added in My list from Event planner.
+        addedActivities: "@fr@ All activities within specified date range are already added to My List.", // Shown when all the activities are added in My list from Event planner.
         activitySearchGeolocationText: "@fr@ Geolocation is not supported in selected browser.", // Shown when searching activity/event using IE8 browser.
         portalUrlNotFound: "@fr@ Portal URL cannot be empty", // Setting error message when portal url is empty.
         activityAlreadyAdded: "@fr@ This feature is already added to list", // Shown when a particular feature already exist in My list and is again attempted to be added to My List.

--- a/js/library/nls/it/localizedStrings.js
+++ b/js/library/nls/it/localizedStrings.js
@@ -94,7 +94,7 @@ define({
         commentString: "@it@ Please enter comment", // Shown when Submit button in Comments pod of infoWindow pod is clicled/tapped without entering the comment.
         maxLengthCommentString: "@it@ Comment should not exceed 250 characters .", // // Shown when Submit button in Comments pod of infoWindow pod is clicled/tapped and the comment string exceeds 250 words.
         commentError: "@it@ Unable to add comments. Comments table is either absent or does not have write access.", // Shown when Submit button in Comments pod of infoWindow pod is clicled/tapped and the application isunable to add comments.
-        addedActivities: "@it@ All activities within specified date range are already added to the My List.", // Shown when all the activities are added in My list from Event planner.
+        addedActivities: "@it@ All activities within specified date range are already added to My List.", // Shown when all the activities are added in My list from Event planner.
         activitySearchGeolocationText: "@it@ Geolocation is not supported in selected browser.", // Shown when searching activity/event using IE8 browser.
         portalUrlNotFound: "@it@ Portal URL cannot be empty", // Setting error message when portal url is empty.
         activityAlreadyAdded: "@it@ This feature is already added to list", // Shown when a particular feature already exist in My list and is again attempted to be added to My List.

--- a/js/library/nls/localizedStrings.js
+++ b/js/library/nls/localizedStrings.js
@@ -95,7 +95,7 @@ define({
             commentString: "Please enter comment", // Shown when Submit button in Comments pod of infoWindow pod is clicled/tapped without entering the comment.
             maxLengthCommentString: "Comment should not exceed 250 characters .", // // Shown when Submit button in Comments pod of infoWindow pod is clicled/tapped and the comment string exceeds 250 words.
             commentError: "Unable to add comments. Comments table is either absent or does not have write access.", // Shown when Submit button in Comments pod of infoWindow pod is clicled/tapped and the application isunable to add comments.
-            addedActivities: "All activities within specified date range are already added to the My List.", // Shown when all the activities are added in My list from Event planner.
+            addedActivities: "All activities within specified date range are already added to My List.", // Shown when all the activities are added in My list from Event planner.
             activitySearchGeolocationText: "Geolocation is not supported in selected browser.", // Shown when searching activity/event using IE8 browser.
             portalUrlNotFound: "Portal URL cannot be empty", // Setting error message when portal url is empty.
             activityAlreadyAdded: "This feature is already added to list", // Shown when a particular feature already exist in My list and is again attempted to be added to My List.

--- a/js/library/themes/styles/blueTheme.css
+++ b/js/library/themes/styles/blueTheme.css
@@ -418,6 +418,7 @@ input {
 
 .esriCTUpAndDownArrow {
     background-color: #007AC2;
+    border-bottom: 1px solid #007AC2;
 }
 
 .esriCTRightArrow, .esriCTLeftArrow {

--- a/js/library/themes/styles/greenTheme.css
+++ b/js/library/themes/styles/greenTheme.css
@@ -435,6 +435,7 @@ input {
 
 .esriCTUpAndDownArrow {
     background-color: #028D6A;
+    border-bottom: 1px solid #028D6A;
 }
 
 .esriCTDivHighlightFacility {

--- a/js/library/themes/styles/mediaQueries.css
+++ b/js/library/themes/styles/mediaQueries.css
@@ -407,10 +407,46 @@
         margin-left: 3px;
     }
 
-    .esriCTdivHeadercontaine, .esriCTdivToggle, .esriCTDivCarouselContent {
+    /*  start for carousel in mobile view   */
+        
+    .esriCTBottomPanelHeight {
+        height: 194px !important;
+    }
+    
+    .esriCTBoxContainer {
+        float: none;
+        width: 100% !important;
+        margin: 0px !important;
+        border-top: none;
+    }
+    
+    .esriCTResultBoxPanelContent {
+        width: 100% !important;
+        margin: 0px !important;
+    }
+    
+    .esriCTBottomPanelPosition {
+        bottom: 193px !important;
+    }
+    
+    #esriCTFacilityInformationPod, #esriCTDirectionsPod, #esriCTGalleryPod, #esriCTCommentsPod {
         display: none !important;
     }
-
+    
+    .esriCTDivLegendBoxUp {
+        bottom: 195px !important;
+    }
+    
+    .esriCTDivMapPositionUp, .esriCTCustomMapLogoPostionChange {
+        bottom: 237px;
+    }
+    
+    .esriCTBottomPanelPosition, .esriCTBottomPanelHeight, .esriCTDivLegendBox, .esriCTHideBottomContainerHeight, .esriCTZeroBottom {
+        position: fixed;
+    }
+    
+    /* end for carousel in mobile view   */
+    
     .esriCTDivMapPositionTop {
         bottom: 45px !important;
     }
@@ -512,10 +548,6 @@
         bottom: 44%;
     }
 
-    .esriCTCustomMapLogoPostionChange {
-        bottom: 35px;
-    }
-
     .esriCTCustomMapLogoPostion {
         bottom: 8px;
     }
@@ -540,20 +572,9 @@
         height: -o-calc(100% - 10px);
     }
 
-    .esriCTDivLegendBoxUp {
-        bottom: 0px;
-    }
-
-    .esriCTDivMapPositionUp {
-        bottom: 0px;
-    }
-
     .esriCTDivLegendBox {
-        width: 100%;
-        bottom: 2px;
         margin-left: 0px;
         z-index: 996;
-        position: fixed;
     }
 
     .esriCTLegendBox {
@@ -589,11 +610,7 @@
     .esriCTActivityMainContainer {
         height: -webkit-calc(100% - 182px);
     }
-
-    .esriCTAddressList {
-        height: 130px;
-    }
-
+    
     .esriCTEventPlannerContainer {
         height: 100px;
     }
@@ -830,9 +847,49 @@
         margin-left: 3px;
     }
 
-    .esriCTdivSplashContent, .esriCTdivToggle, .esriCTDivCarouselContent {
+    /*  start for carousel in mobile view   */
+    
+    .esriCTBottomPanelHeight {
+        height: 194px !important;
+    }
+    
+    .esriCTBoxContainer {
+        float: none;
+        width: 100% !important;
+        margin: 0px !important;
+        border-top: none;
+    }
+    
+    .esriCTResultBoxPanelContent {
+        width: 100% !important;
+        margin: 0px !important;
+    }
+    
+    .esriCTBottomPanelPosition {
+        bottom: 193px !important;
+    }
+         
+    #esriCTFacilityInformationPod, #esriCTDirectionsPod, #esriCTGalleryPod, #esriCTCommentsPod {
         display: none !important;
     }
+    
+    .esriCTSpanFeatureListContainer {
+        padding-right: 15px;
+    }
+    
+    .esriCTDivLegendBoxUp {
+        bottom: 195px;
+    }
+    
+    .esriCTDivMapPositionUp, .esriCTCustomMapLogoPostionChange {
+        bottom: 237px !important;
+    }
+    
+    .esriCTBottomPanelPosition, .esriCTBottomPanelHeight, .esriCTDivLegendBox, .esriCTHideBottomContainerHeight, .esriCTZeroBottom {
+        position: fixed;
+    }
+    
+    /* end for carousel in mobile view   */
 
     .divCarouselContent {
         display: none;
@@ -845,19 +902,7 @@
     .esriCTLegendBox {
         margin-right: 6px !important;
     }
-
-    .esriCTLegendChangePositionUp, .esriCTdivLegendbox {
-        width: 100%;
-        bottom: 0px !important;
-        margin-left: 0px !important;
-    }
-
-    .esriCTLegendChangePositionDown {
-        width: 100%;
-        bottom: 0px !important;
-        margin-left: 0px !important;
-    }
-
+    
     .esriCTActivityList, .esriCTEventPlannerListTable {
         width: 100%;
     }
@@ -953,10 +998,6 @@
         padding: 7px;
     }
 
-    .esriCTCustomMapLogoPostionChange {
-        bottom: 35px;
-    }
-
     .esriCTCustomMapLogoPostion {
         bottom: 8px;
     }
@@ -976,20 +1017,13 @@
         height: -o-calc(100% - 10px);
     }
 
-    .esriCTDivLegendBoxUp {
-        bottom: 0px;
-    }
-
-    .esriCTDivMapPositionUp {
-        bottom: 0px;
+    .esriCTDivMapPositionUp, .esriCTCustomMapLogoPositionChange {
+        bottom: 241px;
     }
 
     .esriCTDivLegendBox {
-        width: 100%;
-        bottom: 2px;
         margin-left: 0px;
         z-index: 996;
-        position: fixed;
     }
 
     .esriCTTabsLeftFlexi {

--- a/js/library/themes/styles/orangeTheme.css
+++ b/js/library/themes/styles/orangeTheme.css
@@ -445,6 +445,7 @@ input {
 
 .esriCTUpAndDownArrow {
     background-color: #d15706;
+    border-bottom: 1px solid #d15706;
 }
 
 .esriCTRightArrow, .esriCTLeftArrow {

--- a/js/library/themes/styles/purpleTheme.css
+++ b/js/library/themes/styles/purpleTheme.css
@@ -464,6 +464,7 @@ input {
 
 .esriCTUpAndDownArrow {
     background-color: #5C2E6F;
+    border-bottom: 1px solid #5C2E6F;
 }
 
 .esriCTRightArrow, .esriCTLeftArrow {

--- a/js/library/themes/styles/theme.css
+++ b/js/library/themes/styles/theme.css
@@ -728,6 +728,7 @@ body {
 
 .esriCTDivClear {
     clear: both;
+    margin-right: 20px;
 }
 
 .esriCTUtilityImgContainer {
@@ -816,7 +817,7 @@ body {
 
 .esriCTCarouselAddToListDiv {
     background-repeat: no-repeat;
-    margin: 12px 12px 0 0;
+    margin: 12px 12px 10px 0;
     width: 24px;
     height: 24px;
     float: right;
@@ -1625,14 +1626,14 @@ body {
     display: table-cell;
     vertical-align: middle;
     padding: 5px 0px 5px 0px;
-    word-break: break-word;
+    word-break: break-all;
 }
 
 .esriCTSecondChild {
     display: table-cell;
     vertical-align: middle;
     padding: 5px 5px 5px 0px;
-    word-break: break-word;
+    word-break: break-all;
 }
 
 .esriCTWordBreak {
@@ -1949,7 +1950,6 @@ input::-ms-clear {
     border: none;
     margin-left: 20px;
     margin-top: 5px;
-    float: left;
     width: 94%;
     width: -moz-calc(100% - 20px);
     width: -webkit-calc(100% - 20px);
@@ -2296,7 +2296,7 @@ a.esriCTinfoWindowHyperlink:hover, a.esriCTinfoWindowHyperlink:active {
 
 .esriCTCustomPopupDiv {
     padding: 0px 5px 0 5px;
-    text-align: justify;
+    text-align: left;
     color: #6e6e6e;
     width: 100%;
 }

--- a/js/library/widgets/carouselContainer/carouselContainer.js
+++ b/js/library/widgets/carouselContainer/carouselContainer.js
@@ -20,16 +20,18 @@ define([
     "dojo/_base/declare",
     "dijit/_WidgetBase",
     "dojo/dom-construct",
+    "dojo/window",
     "dojo/_base/lang",
     "dojo/dom-attr",
     "dojo/dom-style",
     "dojo/dom-class",
+    "dojo/topic",
     "dojo/query",
     "dojo/on",
     "dojo/i18n!application/js/library/nls/localizedStrings",
     "dijit/a11yclick"
 
-], function (declare, WidgetBase, domConstruct, lang, domAttr, domStyle, domClass, query, on, sharedNls, a11yclick) {
+], function (declare, WidgetBase, domConstruct, win, lang, domAttr, domStyle, domClass, topic, query, on, sharedNls, a11yclick) {
 
     //========================================================================================================================//
 
@@ -48,7 +50,12 @@ define([
         * @class
         * @name widgets/carouselContainer/carouselContainer
         */
-
+        postCreate: function () {
+            topic.subscribe("collapseCarousel", lang.hitch(this, function () {
+                this.collapseCarousel();
+                appGlobals.shareOptions.isShowPod = "false";
+            }));
+        },
         /**
         * Create carousel container pod
         * @param {Object} Node in which we want to create carousel pod
@@ -72,16 +79,10 @@ define([
             this.resultboxPanelContent = domConstruct.create("div", { "class": "esriCTResultBoxPanelContent" }, resultboxPanel);
             // On click on image for wipe in and wipeout.
             this.own(on(this.divImageBackground, a11yclick, lang.hitch(this, function () {
-                // Checking condition if pod is added in container
-                if (this.isPodCreated > 0) {
-                    // Checking the class for expanding and collapsing the container.
-                    if (domClass.contains(this.divCarouselContent, "esriCTzeroHeight")) {
-                        this.expandCarousel();
-                        appGlobals.shareOptions.isShowPod = "true";
-                    } else {
-                        this.collapseCarousel();
-                        appGlobals.shareOptions.isShowPod = "false";
-                    }
+                this._toggleCarouselPod();
+                // On mobile close header panels
+                if (win.getBox().w <= 766) {
+                    topic.publish("toggleWidget");
                 }
             })));
             domStyle.set(this.divImageBackground, "display", "none");
@@ -273,6 +274,24 @@ define([
             mapLogoPostionDown = query('.esriControlsBR')[0];
             domClass.remove(mapLogoPostionDown, "esriCTDivMapPositionTop");
             domClass.add(mapLogoPostionDown, "esriCTDivMapPositionUp");
+        },
+
+        /**
+        * set carousel collapse up and down
+        * @memberOf widgets/carouselContainer/carouselContainer
+        */
+        _toggleCarouselPod: function () {
+            // Checking condition if pod is added in container
+            if (this.isPodCreated > 0) {
+                // Checking the class for expanding and collapsing the container.
+                if (domClass.contains(this.divCarouselContent, "esriCTzeroHeight")) {
+                    this.expandCarousel();
+                    appGlobals.shareOptions.isShowPod = "true";
+                } else {
+                    this.collapseCarousel();
+                    appGlobals.shareOptions.isShowPod = "false";
+                }
+            }
         }
     });
 });

--- a/js/library/widgets/commonHelper/carouselContainerHelper.js
+++ b/js/library/widgets/commonHelper/carouselContainerHelper.js
@@ -23,6 +23,7 @@ define([
     "dojo/dom-attr",
     "dojo/_base/lang",
     "dojo/on",
+    "dojo/window",
     "dojo/dom",
     "dojo/dom-class",
     "dojo/query",
@@ -34,7 +35,7 @@ define([
     "dojo/_base/array",
     "widgets/carouselContainer/carouselContainer"
 
-], function (declare, domConstruct, domStyle, domAttr, lang, on, dom, domClass, query, string, _WidgetBase, sharedNls, topic, a11yclick, array, CarouselContainer) {
+], function (declare, domConstruct, domStyle, domAttr, lang, on, win, dom, domClass, query, string, _WidgetBase, sharedNls, topic, a11yclick, array, CarouselContainer) {
     // ========================================================================================================================//
 
     return declare([_WidgetBase], {
@@ -92,20 +93,23 @@ define([
                         }
                         // Switch for carouse pod key for creating div
                         switch (carouselPodKey.toLowerCase()) {
-                        // If it is a search pod
+                        // If it is a search pod 
                         case "searchresultpod":
+                            domAttr.set(divCarouselPod, "id", "esriCTSearchResultPod");
                             divHeader = domConstruct.create("div", { "class": "esriCTDivHeadercontainer" }, divPodInfoContainer);
                             domConstruct.create("div", { "class": "esriCTSpanHeader", "innerHTML": sharedNls.titles.searchResultText }, divHeader);
                             divsearchcontent = domConstruct.create("div", { "class": "esriCTResultContent" }, divHeader);
                             domConstruct.create("div", { "class": "esriCTDivSearchResulContent" }, divsearchcontent);
                             break;
                         case "facilityinformationpod":
+                            domAttr.set(divCarouselPod, "id", "esriCTFacilityInformationPod");
                             // If it is a facility pod
                             this.facilityContainer = domConstruct.create("div", { "class": "esriCTDivHeadercontainer" }, divPodInfoContainer);
                             this.divfacilitycontent = domConstruct.create("div", {}, this.facilityContainer);
                             domConstruct.create("div", { "class": "esriCTdivFacilityContent" }, this.divfacilitycontent);
                             break;
                         case "directionspod":
+                            domAttr.set(divCarouselPod, "id", "esriCTDirectionsPod");
                             // If it is a direction pod
                             if (appGlobals.configData.DrivingDirectionSettings.GetDirections) {
                                 this.directionContainer = domConstruct.create("div", { "class": "esriCTDivHeadercontainer" }, divPodInfoContainer);
@@ -113,6 +117,7 @@ define([
                             }
                             break;
                         case "gallerypod":
+                            domAttr.set(divCarouselPod, "id", "esriCTGalleryPod");
                             // If it is a gallery pod
                             divHeader = domConstruct.create("div", { "class": "esriCTDivHeadercontainer" }, divPodInfoContainer);
                             domConstruct.create("div", { "class": "esriCTSpanHeader", "innerHTML": sharedNls.titles.galleryText }, divHeader);
@@ -120,6 +125,7 @@ define([
                             domConstruct.create("div", { "class": "esriCTDivGalleryContent" }, divGallerycontent);
                             break;
                         case "commentspod":
+                            domAttr.set(divCarouselPod, "id", "esriCTCommentsPod");
                             // If it is a comment pod
                             divHeader = domConstruct.create("div", { "class": "esriCTDivHeadercontainer" }, divPodInfoContainer);
                             domConstruct.create("div", { "class": "esriCTSpanHeader", "innerHTML": sharedNls.titles.commentText }, divHeader);
@@ -248,6 +254,9 @@ define([
                         resultcontent[i] = domConstruct.create("div", { "class": "esriCTSearchResultInfotextForEvent", "innerHTML": result[i].attributes[searchContenData] + milesCalulatedData }, divHeaderContent[0]);
                     }
                 }));
+                if (win.getBox().w <= 766) {
+                    topic.publish("resizeLegendContainer");
+                }
             }
         },
 
@@ -260,6 +269,13 @@ define([
             var pushpinGeometry, widgetName, routeObject, queryObject, highlightedDiv, queryURL, rowIndex;
             this.featureSetWithoutNullValue = searchedFacilityObject.FeatureData;
             topic.publish("hideInfoWindow");
+            /* Collapse Carousel in smartphones */
+            if (win.getBox().w <= 766) {
+                // if any feature is clicked in smartphone's search results then collapse down the carousel result pod
+                topic.publish("collapseCarousel");
+                topic.publish("resizeLegendContainer");
+            }
+            this.zoomToFullRoute = true; /* Setting zoomToFullRoute to true for Github issue #182 */
             // If feature data has some items
             if (searchedFacilityObject.FeatureData.length > 1) {
                 // If event is available then get query URL and row index from event.

--- a/js/library/widgets/commonHelper/commonHelper.js
+++ b/js/library/widgets/commonHelper/commonHelper.js
@@ -67,6 +67,7 @@ define([
             // Check the buffer graphics layer and graphics for removing graphics from map
             if (this.map.getLayer("tempBufferLayer") && this.map.getLayer("tempBufferLayer").graphics.length > 0) {
                 this.map.getLayer("tempBufferLayer").clear();
+                this.zoomToFullRoute = true;
             }
         },
 

--- a/js/library/widgets/commonHelper/directionWidgetHelper.js
+++ b/js/library/widgets/commonHelper/directionWidgetHelper.js
@@ -99,12 +99,14 @@ define([
                     }
                     // Check if direction not null or null then set zoom level of route in share URL
                     if (this._esriDirectionsWidget.directions !== null) {
-                        if (window.location.href.toString().split("$extentChanged=").length > 1) {
-                            if (this.isExtentSet) {
+                        if (this.zoomToFullRoute) {
+                            if (window.location.href.toString().split("$extentChanged=").length > 1) {
+                                if (this.isExtentSet) {
+                                    this._esriDirectionsWidget.zoomToFullRoute();
+                                }
+                            } else {
                                 this._esriDirectionsWidget.zoomToFullRoute();
                             }
-                        } else {
-                            this._esriDirectionsWidget.zoomToFullRoute();
                         }
                         // Switch case for widget name
                         switch (this.routeObject.WidgetName.toLowerCase()) {
@@ -242,7 +244,10 @@ define([
             facilityObject = { "Feature": this.routeObject.EndPoint, "SelectedItem": resultcontent, "QueryURL": this.routeObject.QueryURL, "WidgetName": this.routeObject.WidgetName, "activityData": this.routeObject.activityData };
             this.setFacility(facilityObject);
             // Checking for solve route if direction is not calculated then show address search box
-            if (queryObject.SolveRoute[0].directions && queryObject.SolveRoute[0].directions.totalLength <= 0) {
+            if (queryObject.SolveRoute && queryObject.SolveRoute[0].directions && queryObject.SolveRoute[0].directions.totalLength <= 0) {
+                directionObject = { "Feature": queryObject.FeatureData, "SelectedItem": resultcontent, "SolveRoute": queryObject.SolveRoute, "Address": queryObject.Address, "WidgetName": queryObject.WidgetName, "activityData": queryObject.activityData, "QueryURL": queryObject.QueryURL };
+                this.setDirection(directionObject);
+            } else if (this.routeObject.isLayerCandidateClicked) {
                 this._createAddressSearchTextBox(queryObject, resultcontent);
             } else {
                 directionObject = { "Feature": this.routeObject.EndPoint, "SelectedItem": resultcontent, "SolveRoute": a.result.routeResults, "Address": address, "WidgetName": this.routeObject.WidgetName, "QueryURL": this.routeObject.QueryURL, "activityData": this.routeObject.activityData };
@@ -278,7 +283,7 @@ define([
             geoArray.push(endPointGeometery);
             this.routeObject = routeObject;
             // Updating two stops for direction widget.
-            if (appGlobals.configData.DrivingDirectionSettings.GetDirections) {
+            if (appGlobals.configData.DrivingDirectionSettings.GetDirections && !routeObject.isLayerCandidateClicked) {
                 // For clearing the direction from map and div.
                 this._esriDirectionsWidget.clearDirections();
                 // Function for updating stops and getting direction from direction widget
@@ -524,7 +529,7 @@ define([
         _switchCaseForRoute: function (queryObject, commentArray, featureId, errorMessage) {
             var resultcontent, queryURLLink;
             switch (queryObject.WidgetName.toLowerCase()) {
-                // If it is comming from activity search then set bottom pod's data  
+            // If it is comming from activity search then set bottom pod's data     
             case "activitysearch":
                 topic.publish("showProgressIndicator");
                 resultcontent = { "value": queryObject.Index };
@@ -728,7 +733,10 @@ define([
                 if (queryObject.SolveRoute === null) {
                     this._createAddressSearchTextBox(queryObject, resultcontent);
                 } else {
-                    if (queryObject.SolveRoute[0].directions && queryObject.SolveRoute[0].directions.totalLength <= 0) {
+                    if (queryObject.SolveRoute && queryObject.SolveRoute[0].directions && queryObject.SolveRoute[0].directions.totalLength <= 0) {
+                        directionObject = { "Feature": queryObject.FeatureData, "SelectedItem": resultcontent, "SolveRoute": queryObject.SolveRoute, "Address": queryObject.Address, "WidgetName": queryObject.WidgetName, "activityData": queryObject.activityData, "QueryURL": queryObject.QueryURL };
+                        this.setDirection(directionObject);
+                    } else if (this.routeObject.isLayerCandidateClicked) {
                         this._createAddressSearchTextBox(queryObject, resultcontent);
                     } else {
                         directionObject = { "Feature": queryObject.FeatureData, "SelectedItem": resultcontent, "SolveRoute": queryObject.SolveRoute, "Address": queryObject.Address, "WidgetName": queryObject.WidgetName, "activityData": queryObject.activityData, "QueryURL": queryObject.QueryURL };

--- a/js/library/widgets/geoLocation/geoLocation.js
+++ b/js/library/widgets/geoLocation/geoLocation.js
@@ -64,7 +64,7 @@ define([
                         * minimize other open header panel widgets and call geolocation service
                         */
                         topic.publish("toggleWidget", "geolocation");
-                        this.showCurrentLocation(this.preLoaded, true);
+                        this.showCurrentLocation(this.preLoaded, false);
                     })));
                 }
             }

--- a/js/library/widgets/myList/myList.js
+++ b/js/library/widgets/myList/myList.js
@@ -250,6 +250,9 @@ define([
                 if (query(".esriCTHideMyListContainer")[0]) {
                     domClass.replace(myListContainer, "esriCTShowMyListContainer", "esriCTHideMyListContainer");
                 }
+                if (win.getBox().w <= 766) {
+                    topic.publish("collapseCarousel");
+                }
             }
         },
 
@@ -325,7 +328,7 @@ define([
                 on(myListLeft[j], a11yclick, lang.hitch(this, function (event) {
                     this._clickOnMyListRow(event);
                 }));
-                directionAcitivityList[j] = domConstruct.create("div", {"class": "esriCTDirectionEventListWithoutImage", "value": myListEvent.value }, myListIcons);
+                directionAcitivityList[j] = domConstruct.create("div", { "class": "esriCTDirectionEventListWithoutImage", "value": myListEvent.value }, myListIcons);
                 if (appGlobals.configData.DrivingDirectionSettings.GetDirections) {
                     directionAcitivityList[j].title = sharedNls.tooltips.routeTooltip;
                     domClass.replace(directionAcitivityList[j], "esriCTDirectionEventList", "esriCTDirectionEventListWithoutImage");
@@ -928,7 +931,7 @@ define([
                     }
                 } else {
                     if (widgetName !== "listclick") {
-                        fieldValue = fieldValue.toFixed(popupInfoValue.format.places);
+                        fieldValue = parseFloat(fieldValue).toFixed(popupInfoValue.format.places);
                     }
                 }
             }

--- a/js/library/widgets/searchSetting/eventPlannerHelper.js
+++ b/js/library/widgets/searchSetting/eventPlannerHelper.js
@@ -162,7 +162,7 @@ define([
             this.dateFieldArray = this.getDateField(result);
             resultSet = result.features[0];
             // Calling the show route
-            routeObject = { "StartPoint": resultSet, "EndPoint": [resultSet], "Index": 0, "WidgetName": "unifiedsearch", "QueryURL": URL };
+            routeObject = { "StartPoint": resultSet, "EndPoint": [resultSet], "Index": 0, "WidgetName": "unifiedsearch", "QueryURL": URL, "isLayerCandidateClicked": true };
             topic.publish("showRoute", routeObject);
         },
 

--- a/js/library/widgets/searchSetting/searchSetting.js
+++ b/js/library/widgets/searchSetting/searchSetting.js
@@ -23,6 +23,7 @@ define([
     "dojo/dom-attr",
     "dojo/_base/lang",
     "dojo/on",
+    "dojo/window",
     "dojo/dom-geometry",
     "dojo/dom",
     "dojo/_base/array",
@@ -45,7 +46,7 @@ define([
     "dijit/a11yclick",
     "dojo/date/locale"
 
-], function (declare, domConstruct, domStyle, domAttr, lang, on, domGeom, dom, array, domClass, Query, Deferred, QueryTask, Point, template, _WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin, sharedNls, topic, urlUtils, ActivitySearch, esriRequest, EventPlannerHelper, LocatorTool, a11yclick, locale) {
+], function (declare, domConstruct, domStyle, domAttr, lang, on, win, domGeom, dom, array, domClass, Query, Deferred, QueryTask, Point, template, _WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin, sharedNls, topic, urlUtils, ActivitySearch, esriRequest, EventPlannerHelper, LocatorTool, a11yclick, locale) {
     // ========================================================================================================================//
 
     return declare([_WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin, ActivitySearch, EventPlannerHelper], {
@@ -120,6 +121,9 @@ define([
                 this.isInfowindowHide = true;
                 topic.publish("extentSetValue", true);
                 topic.publish("toggleWidget", "searchSetting");
+                if (win.getBox().w <= 766) {
+                    topic.publish("collapseCarousel");
+                }
                 this._showLocateContainer();
                 // Checking for feature search data of event search if it is present then
                 if (this.featureSet && this.featureSet.length > 0) {
@@ -149,8 +153,10 @@ define([
             })));
             // click on "GO" button in activity search
             this.own(on(this.buttonGo, a11yclick, lang.hitch(this, function () {
+                topic.publish("removeBuffer");
+                topic.publish("clearGraphicsAndCarousel");
+                topic.publish("removeRouteGraphichOfDirectionWidget");
                 topic.publish("hideInfoWindow");
-                topic.publish("removeHighlightedCircleGraphics");
                 topic.publish("extentSetValue", true);
                 this.featureSet.length = 0;
                 this._activityPlannerDateValidation();
@@ -215,7 +221,7 @@ define([
                 if (candidate && candidate.layer) {
                     topic.publish("addCarouselPod");
                     this.selectedLayerTitle = candidate.layer.SearchDisplayTitle;
-                    routeObject = { "StartPoint": candidate, "EndPoint": [candidate], "Index": 0, "WidgetName": "unifiedsearch", "QueryURL": candidate.layer.QueryURL };
+                    routeObject = { "StartPoint": candidate, "EndPoint": [candidate], "Index": 0, "WidgetName": "unifiedsearch", "QueryURL": candidate.layer.QueryURL, "isLayerCandidateClicked": true };
                     topic.publish("showRoute", routeObject);
                     getSearchSettingsDetails = this.getSearchSetting(candidate.layer.QueryURL);
                     objectIDField = candidate.attributes[candidate.layer.ObjectID];

--- a/js/library/widgets/share/share.js
+++ b/js/library/widgets/share/share.js
@@ -199,7 +199,7 @@ define([
             }
             //appGlobals.shareOptions.infowindowDirection variable is use to store the infowindow direction geometry and append in shared URL
             if (appGlobals.shareOptions.infowindowDirection) {
-                urlStr += "$infowindowDirection=" + appGlobals.shareOptions.infowindowDirection.toString();
+                urlStr += "$infowindowDirection=" + appGlobals.shareOptions.directionScreenPoint + "," + appGlobals.shareOptions.infowindowDirection.toString();
             }
             //appGlobals.shareOptions.activitySearch variable is use to store the activity name and append in shared URL
             if (appGlobals.shareOptions.activitySearch) {


### PR DESCRIPTION
Resolved following tickets :
#93  - Searching for Activity yields unecessary graphic
#154 - Jarring zooming behavior when searching
#156 - After getting directions using the popup and closing the popup,
the popup persists in shared version
#157 - Directions in shared version do not route to the same feature
#164 - Custom Pop-up is cut off by scroll bar, add padding to top of pod
#167 - Unchecking the parameter for "Turn On 1000 separator" on a webmap
causes the application to freeze
#168 - Zooming to buffer instead of the route (when searching by
location)
#171 - Unnecessary requests on map initialization and pan
#173 - Changing symbol size in the webmap breaks the legend display
#175 - On phone devices the popup header displays as "N/A" when : is not
present
#176 - When mobile popup window is present collapse menu when user
clicks on name of event
#179 - Update application to clearly show the nearest feature, buffer,
route. (zooms to close to the route now.)
#180 - When event search follows location search, location search is not
cleared from the map
#182 - Smartphones only shows one option when searching for amenities \
parks